### PR TITLE
Add CLI entrypoint to create an admin user

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(neon-users-service|click|RapidFuzz|setuptools|tqdm|typing-inspection|typing_extensions|urllib|click|RapidFuzz|setuptools|tqdm|typing|urllib).*'
+      packages-exclude: '^(neon-users-service|click|RapidFuzz|setuptools|tqdm|typing-inspection|typing_extensions|urllib|click|RapidFuzz|setuptools|tqdm|typing|urllib|orjson).*'

--- a/docker_overlay/opt/neon/healthcheck.sh
+++ b/docker_overlay/opt/neon/healthcheck.sh
@@ -1,29 +1,18 @@
 #!/bin/bash
-# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
-# All trademark and other rights reserved by their respective owners
-# Copyright 2008-2025 Neongecko.com Inc.
-# BSD-3
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-# 1. Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-# 3. Neither the name of the copyright holder nor the names of its
-#    contributors may be used to endorse or promote products derived from this
-#    software without specific prior written permission.
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 port="${HEALTHCHECK_PORT:-8000}"
 # Perform the health check using curl

--- a/neon_users_service/__init__.py
+++ b/neon_users_service/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/__main__.py
+++ b/neon_users_service/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/cli.py
+++ b/neon_users_service/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/cli.py
+++ b/neon_users_service/cli.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2025 Neongecko.com Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional
+from os import environ
+
+import click
+
+from neon_users_service.exceptions import UserExistsError
+
+
+@click.group("neon-users-service",
+             help="Neon Users Service commandline interface.")
+def neon_users_service_cli():
+    pass
+
+
+@neon_users_service_cli.command(help="Start the Neon Users Service")
+@click.option("--health-check-server-port", "-hp", type=int, default=None,
+              help="Port for the health check server to listen on. Defaults "
+                   "to the `HEALTHCHECK_PORT` environment variable.")
+def run(health_check_server_port: Optional[int] = None):
+    """
+    Start the Neon Users Service MQ connector and run until terminated.
+    """
+    from ovos_utils import wait_for_exit_signal
+    from ovos_utils.log import init_service_logger
+    from neon_utils.process_utils import start_health_check_server
+    from neon_users_service.mq_connector import NeonUsersConnector
+
+    init_service_logger("neon-users-service")
+    connector = NeonUsersConnector(None)
+    click.echo("Starting Neon Users Service")
+    status_port = health_check_server_port or environ.get("HEALTHCHECK_PORT")
+    if status_port:
+        start_health_check_server(connector.status, int(status_port),
+                                  connector.check_health)
+    connector.run()
+    click.echo("Started Neon Users Service")
+    wait_for_exit_signal()
+    click.echo("Neon Users Service Shutdown")
+
+
+@neon_users_service_cli.command(help="Create an admin-privileged user.")
+@click.option("--username", "-u", default=None,
+              help="Username of the admin user to create")
+@click.option("--password", "-p", default=None,
+              help="Password for the new admin user. If not provided, you "
+                   "will be prompted to enter one securely.")
+def create_admin(username: str, password: str):
+    """
+    Create a new admin user with the given USERNAME.
+    """
+    from neon_users_service.util.manage_user_db import create_admin_user
+    if not username:
+        username = click.prompt("Username", hide_input=False,
+                                confirmation_prompt=False)
+    if not password:
+        password = click.prompt("Password", hide_input=True,
+                                confirmation_prompt=True)
+    try:
+        user = create_admin_user(username, password)
+        click.echo(f"Created admin user '{user.username}' ({user.user_id})")
+    except UserExistsError:
+        click.echo(f"FAILED TO CREATE. Username already exists: `{username}`")
+
+
+if __name__ == "__main__":
+    neon_users_service_cli()

--- a/neon_users_service/databases/__init__.py
+++ b/neon_users_service/databases/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/databases/mongodb.py
+++ b/neon_users_service/databases/mongodb.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/databases/sqlite.py
+++ b/neon_users_service/databases/sqlite.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/exceptions.py
+++ b/neon_users_service/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/mq_connector.py
+++ b/neon_users_service/mq_connector.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/service.py
+++ b/neon_users_service/service.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/util/__init__.py
+++ b/neon_users_service/util/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2025 Neongecko.com Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/neon_users_service/util/__init__.py
+++ b/neon_users_service/util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/neon_users_service/util/manage_user_db.py
+++ b/neon_users_service/util/manage_user_db.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2025 Neongecko.com Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from neon_data_models.enum import AccessRoles
+from neon_data_models.models.user.database import User, PermissionsConfig
+
+from neon_users_service.service import NeonUsersService
+
+def create_admin_user(username: str, password: str) -> User:
+    """
+    Create an admin-privileged user in the database. Note that there is a
+    higher "OWNER" role that is not defined here; this is intentionally
+    set to `ADMIN` as the minimal requirement to perform routine tasks.
+    @param username: Username of admin user to create
+    @param password: Password of user to create
+    @returns: Created User object
+    """
+    service = NeonUsersService()
+    admin_permissions = PermissionsConfig(klat=AccessRoles.ADMIN,
+                                          core=AccessRoles.ADMIN,
+                                          diana=AccessRoles.ADMIN,
+                                          users=AccessRoles.ADMIN,
+                                          node=AccessRoles.ADMIN,
+                                          hub=AccessRoles.ADMIN,
+                                          llm=AccessRoles.ADMIN)
+
+    # `password` is not hashed, but the service automatically handles hashing
+    new_user = User(username=username, password_hash=password,
+                    permissions=admin_permissions)
+
+    created_user = service.create_user(new_user)
+    return created_user

--- a/neon_users_service/util/manage_user_db.py
+++ b/neon_users_service/util/manage_user_db.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/requirements/mongodb.txt
+++ b/requirements/mongodb.txt
@@ -1,1 +1,1 @@
-pymongo~=4.0
+pymongo~=4.0,<4.14  # 4.14 drops support for MongoDB 4.0 (wire version 7)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 pydantic~=2.0
 ovos-config~=0.1
 ovos-utils~=0.0
-neon-data-models>=0.0.0a4
-neon-utils[sentry]~=1.0,>=1.12.2a2
+neon-data-models~=0.0.2
+neon-utils[sentry]~=1.12
+click~=8.1

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'neon_users_service=neon_users_service.__main__:main'
+            'neon_users_service=neon_users_service.__main__:main',
+            'neon-users-service-cli=neon_users_service.cli:neon_users_service_cli'
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Neongecko.com Inc.
+# Copyright (C) 2008-2026 Neongecko.com Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
# Description
Adds a `create-admin` entrypoint to create a user with administrative permissions
Updates dependencies to ensure compat. with existing MongoDB instances backing public deployments

# Issues
- Closes #6 

# Other Notes
- In most cases, this CLI entrypoint should be run from inside a Docker container deployment
- Deployed to DIANA Alpha namespace and tested manually; confirmed hana.neonaialpha.com returns newly-created `neon-daniel` user
- An image with these changes was pushed as `ghcr.io/neongeckocom/neon-users-service:alpha` when this PR was opened